### PR TITLE
Allow usage of lp: short notation for branches

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -59,7 +59,7 @@ files = bin/rununittests
 
 # openerp configurations
 [openerp]
-recipe = anybox.recipe.openerp:server
+recipe = anybox.recipe.openerp[bzr]:server
 version = git ${src_repo:git_oca}/ocb server ${addons_version:server}
 #        Customer specific addons
 addons = local parts/specific-addons


### PR DESCRIPTION
The anybox recipe needs an extra 'bzr' dependency in order to handle
the Launchpad's Bazaar short notation such as lp:project/branch

Reference:
http://docs.anybox.fr/anybox.recipe.openerp/1.8.0/configuration.html#openerp-recipes
