### PR TITLE
sourcing of a local.cfg file if present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ buildout-odoo
 Base of buildout recipe for odoo servers.
 
 To be deployed as ~/.buildout
+
+
+You may want to manually create ~/.buildout/local.cfg which will be sourced if
+present. It can be used to declare a local shared directory for eggs, such as:
+
+    [buildout]
+    eggs-directory = /home/<yourlogin>/.eggs-cache

--- a/default.cfg
+++ b/default.cfg
@@ -23,6 +23,8 @@ vcs-extend-develop = bzr+ssh://bazaar.launchpad.net/~openerp/openerp-command/7.0
 include-site-packages = false
 exec-sitecustomize = false
 
+[buildout:os.path.isfile(os.path.expanduser('~/.buildout/local.cfg'))]
+extends = local.cfg
 
 [sources]
 odoo_auto_run = git git@github.com:camptocamp/buildout-odoo-recipes branch=openerp_auto_run


### PR DESCRIPTION
this can be used to locally enable a cache of eggs. 
