### PR TITLE
The odoo_auto_run part is loaded but does not exist.

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -103,6 +103,9 @@ options.limit_time_real = 86400
 eggs = xlrd
        argparse  # used by openerp-command
 
+[odoo_auto_run]
+recipe = openerp_auto_run:auto-run
+start_on_boot = yes
 
 [supervisor]
 recipe = collective.recipe.supervisor


### PR DESCRIPTION
Start on boot by default.
The dev files should override the variable:

[odoo_auto_run]
start_on_boot = no
