### PR TITLE
Rename the source 'odoo_auto_run' to 'openerp_auto_run'

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -6,7 +6,7 @@ parts =
     openerp
     supervisor
     python
-    odoo_auto_run
+    auto_run
 
 versions = versions
 
@@ -103,7 +103,7 @@ options.limit_time_real = 86400
 eggs = xlrd
        argparse  # used by openerp-command
 
-[odoo_auto_run]
+[auto_run]
 recipe = openerp_auto_run:auto-run
 start_on_boot = yes
 


### PR DESCRIPTION
The recipe must be referred to using `openerp_auto_run` because the python file in the recipe is `openerp_auto_run.py`.
