### PR TITLE
[IMP] common buildout checkout the Scenarios in order not to have them in addons-path.

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -30,7 +30,7 @@ extends = local.cfg
 [sources]
 openerp_auto_run = git git@github.com:camptocamp/buildout-odoo-recipes branch=openerp_auto_run
 templates = git git@github.com:camptocamp/buildout-odoo-templates egg=false
-scenarios = bzr http://bazaar.launchpad.net/~camptocamp/oerpscenario/trunk-python/ egg=false full-path=Scenario/OERPScenario
+scenarios = git https://github.com/camptocamp/oerpscenario.git egg=false full-path=Scenario/OERPScenario rev=0.5
 
 [src_repo]
 c2c_bzr_oca = sftp://bazaar.camptocamp.net/srv/bzr/upstream/70Official
@@ -77,9 +77,7 @@ addons = local parts/specific-addons
 #        Official addons
          local parts/server/addons
 
-#        OERPScenario
-         bzr ${src_repo:lp_scenario} Scenario/OERPScenario last:1
-         local Scenario/OERPScenario.local
+
 
 
 options.xmlrpc = False


### PR DESCRIPTION
`mr.developer` will do the checkout. The `Scenario`  folder must be present as `mr.developer` will not be able to create parent folder
