### PR TITLE
openerp-command needs ssh whereas http is sufficient

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -20,7 +20,7 @@ auto-checkout =
 find-links = http://download.gna.org/pychart/
 index = http://pypi.camptocamp.net/pypi
 unzip = true
-vcs-extend-develop = bzr+ssh://bazaar.launchpad.net/~openerp/openerp-command/7.0#egg=openerp-command
+vcs-extend-develop = bzr+http://bazaar.launchpad.net/~openerp/openerp-command/7.0#egg=openerp-command
 include-site-packages = false
 exec-sitecustomize = false
 


### PR DESCRIPTION
Using ssh forces users to have a Launchpad account properly configured,
when they could just use http to get the branch.
