### PR TITLE
Enable database logging

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -85,6 +85,8 @@ options.without_demo = True
 options.db_user = ${erp_global:current_instance}
 options.db_name = ${erp_global:current_instance}
 options.db_host = localhost
+options.log_db = ${erp_global:current_instance}
+options.log_db_level = warning
 options.admin_passwd =
 
 # In v6.1 we use Gunicorn


### PR DESCRIPTION
in Odoo >= 8.0 `--log_db <dbname>` allows logging in database.
The logs are readable in Settings > Technical > Database Structure > Logging

This commit enables the setting by default with a in database logging level of
`warning` to avoid having too much data in there. I found this helpful to be able
to check the presence of warnings and errors from the user interface rather
than having to connect to a shell.