### PR TITLE
Add logrotate = True for v8 projects

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -87,6 +87,7 @@ options.db_name = ${erp_global:current_instance}
 options.db_host = localhost
 options.log_db = ${erp_global:current_instance}
 options.log_db_level = warning
+options.logrotate = True
 options.admin_passwd =
 
 # In v6.1 we use Gunicorn


### PR DESCRIPTION
In v8, logrotate defaults to False; it's important to keep it at `True`.