### PR TITLE
Use mr.scripty to define lines for openerp recipe addons based on sec…

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -199,3 +199,28 @@ eggs = behave
        docutils
        decorator
        psutil
+
+[scripty]
+recipe=mr.scripty
+# Define a function to create addons list base on list in addons_versions
+# you can then add addons by putting this:
+#
+# addons = local specific-parts/specific-addons
+#          ${scripty:github_addon_list}
+#
+# and set your addons_versions like this:
+#
+# [addons_version]
+# server=8.0
+# account-financial-tools=oca 8.0
+# c2c-addons=camptocamp 8.0
+GITHUB_ADDON_LINE = git git@github.com:{0}/{1}.git parts/{1} {2}
+github_addon_list =
+    addons_list = []
+    for repo, version in self.buildout['addons_version'].items():
+        version = version.split()
+        if len(version) == 2:
+            repo_owner, ref = version
+            addons_list.append(self.GITHUB_ADDON_LINE.format(repo_owner, repo, ref))
+    print addons_list
+    return "\n".join(addons_list)


### PR DESCRIPTION
…tion [addons_versions] this to avoid having to write for each line 3 times the repository name

An exemple of use in camptocamp/camptocamp_openerp#43

This creates a variable `${scripty:github_addon_list}` containing a list of addons created with the list in addons_version having a value which can be splitted by (owner, tag). For example: carrier-delivery=oca 8.0 

It is backward compatible adding or not the `${scripty:github_addon_list}` variable in addons. As it lists only the addons version made of 2 elements.

This in order to ease addition of repositories and reduce size of common.cfg.

This also avoid error such as forgetting to put the version in `addons_version`

TL; DR
---------

We had:

    [openerp]
    addons=
    ...
        git git@github.com:OCA/webkit-tools.git parts/webkit-tools ${addons_version:webkit-tools}
    ...
    [addons_version]
        webkit-tools=8.0

This make it:

    [openerp]
    addons =
    ...
        ${scripty:github_addon_list}
    ...
    [addons_version]
        webkit-tools=oca 8.0