### PR TITLE
Do not use index http://pypi.camptocamp.net/pypi

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -22,7 +22,6 @@ always-checkout = force
 # see https://pypi.python.org/pypi/mr.developer#id53
 
 find-links = http://download.gna.org/pychart/
-index = http://pypi.camptocamp.net/pypi
 unzip = true
 vcs-extend-develop = bzr+http://bazaar.launchpad.net/~openerp/openerp-command/7.0#egg=openerp-command
 include-site-packages = false


### PR DESCRIPTION
As discussed on our mailing-list, we are not sure that we still need our
local index.  We will no longer use it and see.  If we have issues with
the pypi index, we'll consider to enable it again.

One of the issue is that Travis uses unnecessary bandwidth for the eggs.