### PR TITLE
Fix PyXML and pychart dependencies

### DIFF
--- a/default.cfg
+++ b/default.cfg
@@ -21,7 +21,7 @@ auto-checkout =
 always-checkout = force
 # see https://pypi.python.org/pypi/mr.developer#id53
 
-find-links = http://download.gna.org/pychart/
+find-links = http://pkgs.fedoraproject.org/repo/pkgs/PyXML/PyXML-0.8.3.tar.gz
 unzip = true
 vcs-extend-develop = bzr+http://bazaar.launchpad.net/~openerp/openerp-command/7.0#egg=openerp-command
 include-site-packages = false


### PR DESCRIPTION
PyXML is a dependence of 6.0 and 6.1 OpenERP setup and the projet has been deleted as announced on Python sig-xml.
Pychart is not anymore hosted on gna and it is back on pipy.